### PR TITLE
add a default in the agreement for empty value

### DIFF
--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -35,13 +35,13 @@
       By participating in this study, you understand that:
     </p>
     <ul>
-      {% if data.compensation == "No" %}
-        <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
-      {% else %}
+      {% if data.compensation == "Yes" %}
         <li>You are volunteering to participate. You can stop at any time for any reason.</li>
         <li>For your {{ defaultValue("session_duration") }} of input, you will receive a one-time {{ defaultValue("compensation_method") }} of up to {{ defaultValue("compensation_value") }}. This is taxable income.</li>
         <li>Should you decide to stop participating, you will receive a one-time payment of $10 if you have provided at least 8.5 minutes of input.</li>
         <li>If you have provided less than 8.5 minutes you will be entitled to $0</li>
+      {% else %}
+        <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
       {% endif %}
 
       {% if data.confidentiality == "form.confidential" or data.confidentiality == "form.anonymized" or data.confidentiality == "form.anonymous" %}
@@ -153,10 +153,10 @@
       <p>If you have consented to being recorded, the recording may be disclosed to other departments for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed")}}.</p>
     {% endif %}
 
-    {% if data.compensation == "No" %}
-      <p>CDS may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
+    {% if data.compensation == "Yes" %}
+      <p>CDS will own the {{ defaultValue("research_method") }} information and may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
     {% else %}
-     <p>CDS will own the {{ defaultValue("research_method") }} information and may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
+      <p>CDS may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
     {% endif %}
 
     <h3>Who we are</h3>

--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -10,25 +10,25 @@
     <p>
         For any questions about this research, please contact:
         <br>
-        <strong>{{ data.researcher_name }}</strong>
+        <strong>{{ defaultValue("researcher_name") }}</strong>
         <br>
-        <strong>{{ data.researcher_phone }}</strong>
+        <strong>{{ defaultValue("researcher_phone") }}</strong>
         <br>
-        <strong>{{ data.researcher_email }}</strong>
+        <strong>{{ defaultValue("researcher_email") }}</strong>
     </p>
 
     <p>
     Thank you for volunteering to talk to us.
     We work with the Canadian Digital Service (CDS).
     {% if data.is_with_partner == "Yes" %}
-      We are working with {{ data.partner_department_name }}  ({{ data.partner_department_acronym }}) to {{ data.research_goal }}.
+      We are working with {{ defaultValue("partner_department_name") }}  ({{ defaultValue("partner_department_acronym") }}) to {{ defaultValue("research_goal") }}.
     {% else %}
-      We are conducting this research today to help us {{ data.research_goal }}.
+      We are conducting this research today to help us {{ defaultValue("research_goal") }}.
     {% endif %}
     </p>
 
     <p>
-      To do this we will ask you to {{ data.session_activity }}. This will take {{ data.session_duration }}.
+      To do this we will ask you to {{ defaultValue("session_activity") }}. This will take {{ defaultValue("session_duration") }}.
     </p>
 
     <p>
@@ -39,7 +39,7 @@
         <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
       {% else %}
         <li>You are volunteering to participate. You can stop at any time for any reason.</li>
-        <li>For your {{ data.session_duration }} of input, you will receive a one-time {{ data.compensation_method }} of up to {{ data.compensation_value }}. This is taxable income.</li>
+        <li>For your {{ defaultValue("session_duration") }} of input, you will receive a one-time {{ defaultValue("compensation_method") }} of up to {{ defaultValue("compensation_value") }}. This is taxable income.</li>
         <li>Should you decide to stop participating, you will receive a one-time payment of $10 if you have provided at least 8.5 minutes of input.</li>
         <li>If you have provided less than 8.5 minutes you will be entitled to $0</li>
       {% endif %}
@@ -57,7 +57,7 @@
       {% endif %}
 
       {% if data.confidentiality == "form.public" %}
-        <li>CDS will share publicly {{ data.personal_information_disclosed_to_public }}.</li>
+        <li>CDS will share publicly {{ defaultValue("personal_information_disclosed_to_public") }}.</li>
       {% endif %}
 
       {% if data.confidentiality == "form.anonymous" or data.confidentiality == "form.anonymized" %}
@@ -69,9 +69,10 @@
       {% endif %}
 
       {% if data.is_with_partner == "Yes" %}
-        <li>CDS and {{ data.partner_department_acronym }} may collect your personal information. For example, your {{ data.personal_information_collected }}. To learn about how CDS and {{ data.partner_department_acronym }} protect your personal information, please see the attached privacy statement.</li>
+        <li>CDS and {{ defaultValue("partner_department_acronym")}} may collect your personal information. For example, your {{ defaultValue("personal_information_collected") }}. 
+        To learn about how CDS and {{ defaultValue("partner_department_acronym") }} protect your personal information, please see the attached privacy statement.</li>
       {% else %}
-        <li>CDS may collect your personal information. For example, your {{ data.personal_information_collected }}. To learn about how CDS protects your personal information, please see the attached privacy statement.</li>
+        <li>CDS may collect your personal information. For example, your {{ defaultValue("personal_information_collected") }}. To learn about how CDS protects your personal information, please see the attached privacy statement.</li>
       {% endif %}
 
       {% if data.compensation == "Yes" %}
@@ -132,14 +133,14 @@
     <p>Participation is completely voluntary.</p>
 
     <h3>What we will collect</h3>
-    <p>By participating in this research you consent that your {{ data.personal_information_collected }} will be collected.</p>
+    <p>By participating in this research you consent that your {{ defaultValue("personal_information_collected") }} will be collected.</p>
     <h3>How we will use this information</h3>
 
     {% if data.compensation == "No" %}
-      <p>The Canadian Digital Service (CDS) will use this information to {{ data.research_goal }}.</p>
+      <p>The Canadian Digital Service (CDS) will use this information to {{ defaultValue("research_goal") }}.</p>
       <p>We collect this information to ensure our research cohorts are diverse and to identify trends in feedback for specific groups.</p>
     {% else %}
-      <p>The Canadian Digital Service (CDS) will use this information to {{ data.research_goal }}.</p>
+      <p>The Canadian Digital Service (CDS) will use this information to {{ defaultValue("research_goal") }}.</p>
       <p>We collect this information to ensure our research cohorts are diverse and to identify trends in feedback for specific groups, and to provide you with compensation.</p>
       <p>Please note, you may be contacted at a later date to verify you have received compensation.</p>
     {% endif %}
@@ -149,13 +150,13 @@
     {% endif %}
 
     {% if data.recording_type != "No recording" %}
-      <p>If you have consented to being recorded, the recording may be disclosed to other departments for {{ data.purposes_for_which_the_recording_may_be_disclosed }}.</p>
+      <p>If you have consented to being recorded, the recording may be disclosed to other departments for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed")}}.</p>
     {% endif %}
 
     {% if data.compensation == "No" %}
       <p>CDS may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
     {% else %}
-     <p>CDS will own the {{ data.research_method }} information and may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
+     <p>CDS will own the {{ defaultValue("research_method") }} information and may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
     {% endif %}
 
     <h3>Who we are</h3>
@@ -164,7 +165,7 @@
     <ul>
       <li>The collection and use of your personal information by TBS is authorized by the <i>Financial Administration Act</i>. </li>
       {% if data.is_with_partner == "Yes" %}
-        <li>The collection and use of your personal information by {{ data.partner_department_acronym }} is authorized by the _{{ data.partner_department_authority }}_ .</li>
+        <li>The collection and use of your personal information by {{ defaultValue("partner_department_acronym") }} is authorized by the _{{ defaultValue("partner_department_authority") }}_ .</li>
       {% endif %}
       <li>The collection, use, and disclosure of your personal information is in accordance with the federal <i>Privacy Act</i>. Under the <i>Privacy Act</i>, you have a right of protection, access to and correction or notation of your personal information.</li>
     </ul>

--- a/views/base.njk
+++ b/views/base.njk
@@ -5,6 +5,7 @@
 {% from 'checkboxes.njk' import checkBoxes as checkBoxes with context %}
 {% from 'buttons.njk' import formButtons as formButtons with context %}
 {% from 'input-file.njk' import fileInput as fileInput with context %}
+{% from 'default-value.njk' import defaultValue as defaultValue with context %}
 
 <!DOCTYPE html>
 <html lang="{{ 'en' if getLocale() === 'fr' else 'en' }}">

--- a/views/macros/default-value.njk
+++ b/views/macros/default-value.njk
@@ -10,6 +10,6 @@
     <span style="color:red; font-weight:bold">
       **{{ property }}**
     </span>
-  {% endif%}
+  {% endif %}
 
 {% endmacro %}

--- a/views/macros/default-value.njk
+++ b/views/macros/default-value.njk
@@ -1,0 +1,15 @@
+{#
+  - `property`: form value to look up
+#}
+
+{% macro defaultValue(property) %}
+
+  {% if data[property] %}
+    {{ data[property] }}
+  {% else %}
+    <span style="color:red; font-weight:bold">
+      **{{ property }}**
+    </span>
+  {% endif%}
+
+{% endmacro %}


### PR DESCRIPTION
resolves #24 

added a new macro to show the name of the key in the agreement if the form item wasn't filled in.