### PR TITLE
add toggling to complicated questions

### DIFF
--- a/public/js/toggle-area.js
+++ b/public/js/toggle-area.js
@@ -16,7 +16,7 @@ const toggleArea = event => {
 
   if (!target) return
 
-  if (toggleState === 'on') {
+  if (toggleState.includes('on')) {
     target.style.display = 'block'
   } else {
     target.style.display = 'none'

--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -111,17 +111,17 @@
         <h2>OPTIONAL AUDIO RECORDING</h2>
       {% endif %}
 
-      <p>Recording our research will help us ensure we capture all of your input. Sharing our sessions with other departments will help illustrate the value of {research_method}s with users in building better digital services.</p>
+      <p>Recording our research will help us ensure we capture all of your input. Sharing our sessions with other departments will help illustrate the value of {{ defaultValue("research_method") }}s with users in building better digital services.</p>
 
       <p>By agreeing to be recorded, you understand that:</p>
       <ul>
         <li>You are choosing to be recorded;</li>
         <li>You are not to provide any additional information that would allow others to identify you during the recording (e.g., Name, date of birth, address, etc.)</li>
-        <li>Your responses will not be confidential due to your audio likeness in the recording, and may be shared with other departments for {{ data.purposes_for_which_the_recording_may_be_disclosed }}; and,</li>
+        <li>Your responses will not be confidential due to your audio likeness in the recording, and may be shared with other departments for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed") }}; and,</li>
         <li>If you decide to withdraw your consent, CDS will not share your recording further.</li>
       </ul>
 
-      <p>However, prior to your withdrawal, CDS may have already shared your recording with other departments, which may continue to use the recording for {{ data.purposes_for_which_the_recording_may_be_disclosed }}</p>
+      <p>However, prior to your withdrawal, CDS may have already shared your recording with other departments, which may continue to use the recording for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed") }}.</p>
 
       <p>[ ] I understand the points above and consent to be recorded.</p>
 

--- a/routes/questions-1/questions-1.njk
+++ b/routes/questions-1/questions-1.njk
@@ -47,7 +47,13 @@
                 {{ radioButtons('compensation_method', { '1':'Mastercard gift card','2':'VISA gift card'}, data.compensation_method, 'form.compensation_method', errors) }}
                 {{ radioButtons('compensation_value', { '1':'$50 (For 1 hour of their time)','2':'$25 (For 1/2 hour of their time)','3':'$10 (For 8.5 min of their time (minimum))'}, data.compensation_value, 'form.compensation_value', errors) }}
             </div>
-            {{ radioButtons('confidentiality', { '1':'form.anonymized','2':'form.anonymous','3':'form.confidential','4':'form.not_confidential','5':'form.public'}, data.confidentiality, 'form.confidentiality', errors) }}
+
+            <div class="toggle-area">
+            {{ radioButtons('confidentiality', { 'off-1':'form.anonymized','off-2':'form.anonymous','off-3':'form.confidential','on-1':'form.not_confidential','on-2':'form.public'}, data.confidentiality, 'form.confidentiality', errors) }}
+            </div>
+            <div class="confidentiality-toggled" style="display:none" >
+                {{ textArea('form.personal_information_disclosed_to_public', null, null, data.personal_information_disclosed_to_public, { class: "w-3-4", name: "personal_information_disclosed_to_public", id: "personal_information_disclosed_to_public", autofocus: '', value: data.personal_information_disclosed_to_public }) }}
+            </div>
 
             <div class="toggle-area">
                 {{ radioButtons('administrative_decision', { 'on':'Yes','off':'No'}, data.administrative_decision, 'form.administrative_decision', errors) }}
@@ -60,12 +66,12 @@
 
             {{ radioButtons('is_business', { '1':'Yes','2':'No'}, data.is_business, 'form.is_business', errors) }}
 
-            {{ radioButtons('recording_type', { '1':'Audio only','2':'Video and audio','3':'No recording','4':'Screen recording only','5':'Screen recording with audio'}, data.recording_type, 'form.recording_type', errors) }}
-
-            {{ textArea('form.purposes_for_which_the_recording_may_be_disclosed', null, null, data.purposes_for_which_the_recording_may_be_disclosed, { class: "w-3-4", name: "purposes_for_which_the_recording_may_be_disclosed", id: "purposes_for_which_the_recording_may_be_disclosed", autofocus: '', value: data.purposes_for_which_the_recording_may_be_disclosed }) }}
-
-            {{ textArea('form.personal_information_disclosed_to_public', null, null, data.personal_information_disclosed_to_public, { class: "w-3-4", name: "personal_information_disclosed_to_public", id: "personal_information_disclosed_to_public", autofocus: '', value: data.personal_information_disclosed_to_public }) }}
-
+            <div class="toggle-area">
+                {{ radioButtons('recording_type', { 'on-1':'Video and audio','on-2':'Audio only','on-3':'Screen recording with audio','off-1':'Screen recording only','off-2':'No recording'}, data.recording_type, 'form.recording_type', errors) }}
+            </div>
+            <div class="recording_type-toggled" style="display:none" >
+                {{ textArea('form.purposes_for_which_the_recording_may_be_disclosed', null, null, data.purposes_for_which_the_recording_may_be_disclosed, { class: "w-3-4", name: "purposes_for_which_the_recording_may_be_disclosed", id: "purposes_for_which_the_recording_may_be_disclosed", autofocus: '', value: data.purposes_for_which_the_recording_may_be_disclosed }) }}
+            </div>
             {{ formButtons() }}
         </form>
     </div>


### PR DESCRIPTION
Adds toggling to two questions that original method wouldn't work with because there were more than 2 options: 
- "How will you protect the participant's privacy?"
- "How will you be recording the participant?"