### PR TITLE
set initial toggle state correctly

### DIFF
--- a/public/js/toggle-area.js
+++ b/public/js/toggle-area.js
@@ -9,12 +9,13 @@ const toggleArea = event => {
   // - future {attributes : {data-something: "something"}, values: { '1':'Yes','2':'No'}}
   const toggleState = event.target.getAttribute('data-index')
   const name = event.target.name
+  const checked = event.target.checked
 
   // look for an element with that name of the target + -toggled
   // i.e. div you want to show or hide
   const target = document.querySelector(`.${name}-toggled`)
 
-  if (!target) return
+  if (!checked || !target) return
 
   if (toggleState === 'on') {
     target.style.display = 'block'
@@ -27,5 +28,6 @@ const toggleArea = event => {
 const toggles = document.querySelectorAll('.toggle-area input')
 
 toggles.forEach(el => {
+  toggleArea({ target: el })
   el.addEventListener('click', toggleArea)
 })


### PR DESCRIPTION
There was a problem where if you had a radio button selected and reloaded the page, the toggled-on questions would not be show. This PR essentially does an initial toggle on page load to show or hide them as required.