### PR TITLE
fix variable name showing up in agreement

### DIFF
--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -46,14 +46,18 @@
         <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
       {% endif %}
 
-      {% if data.confidentiality == "form.confidential" or data.confidentiality == "form.anonymized" or data.confidentiality == "form.anonymous" %}
-        <li>Your information will be {{ data.confidentiality }}. This means your responses will not be linked to you.</li>
-      {% endif %}
-
-      {% if data.confidentiality == "form.public" or data.confidentiality == "form.not_confidential" %}
-        <li>Your information will be {{ data.confidentiality }}. Your input will be associated with your name.</li>
-      {% endif %}
-
+      {% if data.confidentiality == "form.confidential" %}
+        <li>Your information will be confidential. This means your responses will not be linked to you.</li>
+      {% elif data.confidentiality == "form.anonymized" %}
+        <li>Your information will be anonymized. This means your responses will not be linked to you.</li>
+      {% elif data.confidentiality == "form.anonymous" %}
+        <li>Your information will be anonymous. This means your responses will not be linked to you.</li>
+      {% elif data.confidentiality == "form.public" %}
+        <li>Your information will be public. Your input will be associated with your name.</li>
+      {% elif data.confidentiality == "form.not_confidential" %}
+        <li>Your information will not be confidential. Your input will be associated with your name.</li>
+      {% endif %}      
+      
       {% if data.compensation == "Yes" %}
          <li>The fact that you participated will not be confidential.</li>
       {% endif %}

--- a/routes/agreement-1/agreement-1-fr.njk
+++ b/routes/agreement-1/agreement-1-fr.njk
@@ -46,12 +46,16 @@
         <li>If you have provided less than 8.5 minutes you will be entitled to $0</li>
       {% endif %}
 
-      {% if data.confidentiality == "form.confidential" or data.confidentiality == "form.anonymized" or data.confidentiality == "form.anonymous" %}
-        <li>Your information will be {{ defaultValue("confidentiality") }}. This means your responses will not be linked to you.</li>
-      {% endif %}
-
-      {% if data.confidentiality == "form.public" or data.confidentiality == "form.not_confidential" %}
-        <li>Your information will be {{ defaultValue("confidentiality") }}. Your input will be associated with your name.</li>
+      {% if data.confidentiality == "form.confidential" %}
+        <li>Your information will be confidential. This means your responses will not be linked to you.</li>
+      {% elif data.confidentiality == "form.anonymized" %}
+        <li>Your information will be anonymized. This means your responses will not be linked to you.</li>
+      {% elif data.confidentiality == "form.anonymous" %}
+        <li>Your information will be anonymous. This means your responses will not be linked to you.</li>
+      {% elif data.confidentiality == "form.public" %}
+        <li>Your information will be public. Your input will be associated with your name.</li>
+      {% elif data.confidentiality == "form.not_confidential" %}
+        <li>Your information will not be confidential. Your input will be associated with your name.</li>
       {% endif %}
 
       {% if data.compensation == "Yes" %}


### PR DESCRIPTION
re #63 

fix item 1: “Your information will be form.confidential. This means your responses will not be linked to you.”