### PR TITLE
add italics to collection authority

### DIFF
--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -167,7 +167,7 @@
     <ul>
       <li>The collection and use of your personal information by TBS is authorized by the <i>Financial Administration Act</i>. </li>
       {% if data.is_with_partner == "Yes" %}
-        <li>The collection and use of your personal information by {{ defaultValue("partner_department_acronym") }} is authorized by the _{{ defaultValue("partner_department_authority") }}_ .</li>
+        <li>The collection and use of your personal information by {{ defaultValue("partner_department_acronym") }} is authorized by the <i>{{ defaultValue("partner_department_authority") }}</i>.</li>
       {% endif %}
       <li>The collection, use, and disclosure of your personal information is in accordance with the federal <i>Privacy Act</i>. Under the <i>Privacy Act</i>, you have a right of protection, access to and correction or notation of your personal information.</li>
     </ul>


### PR DESCRIPTION
Fix fourth item in #63 : add italics around collection authority (previously had underscores around it).