### PR TITLE
Replaced cancel with skip

### DIFF
--- a/routes/translations-1/translations-1.controller.js
+++ b/routes/translations-1/translations-1.controller.js
@@ -16,6 +16,7 @@ module.exports = app => {
         ...routeUtils.getViewData(req, {
           otherLanguage: `_${otherLanguage}`,
           language: `_${language}`,
+          skipUrl: routeUtils.getRouteByName('agreement-1').path,
         }),
         jsFiles,
       })

--- a/routes/translations-1/translations-1.njk
+++ b/routes/translations-1/translations-1.njk
@@ -55,7 +55,7 @@
             {% endif %}
 
 
-            {{ formButtonsSkip() }}
+            {{ formButtonsSkip(skipUrl, 'Skip', 'Continue') }}
         </form>
     </div>
 

--- a/views/macros/buttons.njk
+++ b/views/macros/buttons.njk
@@ -9,16 +9,13 @@
     </div>
 {% endmacro %}
 
-{% macro formButtonsSkip(submitButtonText = 'Continue', cancelUrl = '/clear', skipButtonText = 'Skip') %}
+{% macro formButtonsSkip(skipUrl, skipButtonText = 'Skip', submitButtonText = 'Continue') %}
     <div class="buttons">
         <div class="buttons--left">
             <button type="submit">{{ __(submitButtonText) }}</button>
         </div>
-        <div class="buttons--centre">
-            <button type="submit">{{ __(skipButtonText) }}</button>
-        </div>
         <div class="buttons--right">
-            <a class="button-link transparent full-width" href="{{ cancelUrl }}">{{ __('Cancel') }}</a>
+            <a class="button-link transparent full-width" href="{{ skipUrl }}">{{ __(skipButtonText) }}</a>
         </div>
     </div>
 {% endmacro %}


### PR DESCRIPTION
Closes #80 

Now this button actually does do something different from Continue - if you have entered translations on /translations-1, pressing skip will prevent these from being saved.