### PR TITLE
render properly after validation

### DIFF
--- a/routes/questions-1/questions-1.controller.js
+++ b/routes/questions-1/questions-1.controller.js
@@ -3,6 +3,16 @@ const { routeUtils } = require('./../../utils')
 const { Schema } = require('./schema.js')
 const i18n = require('i18n')
 
+const getData = (req, name) => {
+  const jsFiles = ['js/toggle-area.js']
+
+  const data = routeUtils.getViewData(req, {
+    jsFiles: jsFiles,
+    language: `_${i18n.getLocale(req)}`,
+  })
+  return data
+}
+
 module.exports = app => {
   const name = 'questions-1'
   const route = routeUtils.getRouteByName(name)
@@ -11,11 +21,8 @@ module.exports = app => {
 
   app
     .get(route.path, (req, res) => {
-      const jsFiles = ['js/toggle-area.js']
-      res.render(name, {
-        ...routeUtils.getViewData(req, { data: req.query, language: `_${i18n.getLocale(req)}` }),
-        jsFiles,
-      })
+      global.getData = getData
+      res.render(name, getData(req, name))
     })
     .post(route.path, [
       ...routeUtils.getDefaultMiddleware({ schema: Schema, name: name }),

--- a/routes/questions-1/questions-1.controller.js
+++ b/routes/questions-1/questions-1.controller.js
@@ -4,10 +4,8 @@ const { Schema } = require('./schema.js')
 const i18n = require('i18n')
 
 const getData = (req, name) => {
-  const jsFiles = ['js/toggle-area.js']
-
   const data = routeUtils.getViewData(req, {
-    jsFiles: jsFiles,
+    jsFiles: ['js/toggle-area.js'],
     language: `_${i18n.getLocale(req)}`,
   })
   return data

--- a/utils/validate.helpers.js
+++ b/utils/validate.helpers.js
@@ -98,10 +98,12 @@ const renderPageWithErrors = (
   options = { template: '', errors: [] },
 ) => {
   return res.status(422).render(options.template, {
-    data: getSessionData(req),
     name: options.template,
     body: req.body,
     errors: options.errors,
+    ...(global.getData
+      ? global.getData(req, options.template)
+      : { data: getSessionData(req) }),
   })
 }
 


### PR DESCRIPTION
resolves #89 
fixes #30 #90 

the validation errors screen is rendered by a helper, not the route, so the stuff we are adding into data in the route (`language`, `jsFiles`) aren't available after to the post-validation render. This hack fixes that (thanks @timarney !)