### PR TITLE
change the way language is put in link

### DIFF
--- a/routes/email-link/email-link.controller.js
+++ b/routes/email-link/email-link.controller.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const url = require('url')
 const { getNextRoute, routeUtils, sendNotification } = require('./../../utils')
+const i18n = require('i18n')
 
 module.exports = app => {
   const name = 'email-link'
@@ -11,7 +12,7 @@ module.exports = app => {
   app
     .get(route.path, (req, res) => {
       const data = routeUtils.getViewData(req, {}).data
-      var queryParams = {}
+      const queryParams = { lang: i18n.getLocale(req) }
       Object.keys(data)
         .filter(
           key =>

--- a/routes/questions-1/questions-1.controller.js
+++ b/routes/questions-1/questions-1.controller.js
@@ -1,12 +1,10 @@
 const path = require('path')
 const { routeUtils } = require('./../../utils')
 const { Schema } = require('./schema.js')
-const i18n = require('i18n')
 
 const getData = (req, name) => {
   const data = routeUtils.getViewData(req, {
     jsFiles: ['js/toggle-area.js'],
-    language: `_${i18n.getLocale(req)}`,
     data: req.query,
   })
   return data

--- a/routes/questions-1/questions-1.njk
+++ b/routes/questions-1/questions-1.njk
@@ -8,7 +8,6 @@
         <form method="post" class="form">
 
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-            <input type="hidden" name="language" value={{ language }}>
 
             <h2>{{ __('contactInfo.title') }}</h2>
 


### PR DESCRIPTION
fix #125 

change the `language=_en` that was occuring to `lang=en` (and similarly for the French page)