### PR TITLE
only forward lang query param to agreement

### DIFF
--- a/utils/route.helpers.js
+++ b/utils/route.helpers.js
@@ -2,6 +2,7 @@ const { checkSchema } = require('express-validator')
 const { routes: defaultRoutes } = require('../config/routes.config')
 const { checkErrors } = require('./validate.helpers')
 const url = require('url')
+const i18n = require('i18n')
 
 const DefaultRouteObj = { name: false, path: false }
 
@@ -81,7 +82,7 @@ const getNextRouteURL = (name, req) => {
 
   return url.format({
     pathname: nextRoute.path,
-    query: req.query,
+    query: { lang: i18n.getLocale(req) },
   })
 }
 
@@ -133,7 +134,7 @@ const doRedirect = routeName => {
     }
 
     const nextRoutePath = getNextRouteURL(routeName, req)
-    
+
     return res.redirect(nextRoutePath)
   }
 }


### PR DESCRIPTION
resolves #128 

if you open the app via the emailed link, the query params get passed to the agreement page, but they aren't parsed there. So useless and confusing. 

In this PR we only pass along the `lang` param (so the language is preserved)