### PR TITLE
Remove consent signature when compensating

### DIFF
--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -116,7 +116,7 @@
         Date: _________________________ Time: _________________________
       {% endif %}
 
-      {% if data.consent == "on paper" %}
+      {% if data.consent == "on paper" and data.compensation != "yes" %}
         [ ] <b>I understand the points above and consent to participate in the research.</b>
         <br>
         Name: _________________________      Date: _________________________

--- a/routes/agreement-1/agreement-1-fr.njk
+++ b/routes/agreement-1/agreement-1-fr.njk
@@ -117,7 +117,7 @@
         Date : _________________________ Heure : _________________________
       {% endif %}
 
-      {% if data.consent == "on paper" %}
+      {% if data.consent == "on paper" and data.compensation != "yes" %}
         [ ] <b>Je comprends ce qui précède et je consens à participer à la recherche.</b>
         <br>
         Nom : _________________________      Date : _________________________


### PR DESCRIPTION
Per findings from recent research sessions with compensation, it can be confusing for participants to sign their names multiple times. When compensating, we always attach the s.41 page, which has the lines "I consent to the above and agree to participate", name, signature, and date. So, we don’t need to ask for written consent when compensating, because it’s already part of the compensation process.

(Recommendation from @srtalbot.)