### PR TITLE
Plain language version of participant form

### DIFF
--- a/routes/agreement-1/agreement-1-en.njk
+++ b/routes/agreement-1/agreement-1-en.njk
@@ -38,11 +38,11 @@
 
     <p>
     Thank you for volunteering to talk to us.
-    We work with the Canadian Digital Service (CDS).
+    We work for the Canadian Digital Service (CDS).
     {% if data.is_with_partner == "yes" %}
       We are working with {{ defaultValue("partner_department_name") }} ({{ defaultValue("partner_department_acronym") }}) to {{ defaultValue("research_goal") }}.
     {% else %}
-      We are conducting this research today to help us {{ defaultValue("research_goal") }}.
+      We're conducting this research today to help us {{ defaultValue("research_goal") }}.
     {% endif %}
     </p>
 
@@ -51,57 +51,56 @@
     </p>
 
     <p>
-      By participating in this study, you understand that:
+      By participating in this research session, you understand that:
     </p>
     <ul>
       {% if data.compensation == "yes" %}
-        <li>You are volunteering to participate. You can stop at any time for any reason.</li>
-        <li>For your {{ defaultValue("session_duration") }} of input, you will receive a one-time {{ defaultValue("compensation_method") }} of up to {{ defaultValue("compensation_value") }}. This is taxable income.</li>
-        <li>Should you decide to stop participating, you will receive a one-time payment of $10 if you have provided at least 8.5 minutes of input.</li>
-        <li>If you have provided less than 8.5 minutes you will be entitled to $0</li>
+        <li>you can choose to stop participating at any time for any reason, there are no consequences</li>
+        <li>you will receive {{ defaultValue("compensation_value") }} on a {{ defaultValue("compensation_method") }} if you take part for {{ defaultValue("session_duration") }} – you'll need to declare this on your tax return</li>
+        <li>if you decide to stop participating, you'll receive a payment of $10 if you've spent at least 8.5 minutes taking part</li>
+        <li>if you've taken part for less than 8.5 minutes, you won't receive a payment.</li>
       {% else %}
-        <li>You are volunteering to participate. You can stop at any time for any reason, without any consequences.</li>
+        <li>you can choose to stop participating at any time for any reason, there are no consequences.</li>
       {% endif %}
 
       {% if data.confidentiality == "form.confidential" %}
-        <li>Your information will be confidential. This means your responses will not be linked to you.</li>
+        <li>The people who interview you will know your identity, but no one else will. The responses you give won't be linked to you.</li>
       {% elif data.confidentiality == "form.anonymized" %}
-        <li>Your information will be anonymized. This means your responses will not be linked to you.</li>
+        <li>The information you give us will be anonymized. No one will be able to link your responses to you once anonymization is completed.</li>
       {% elif data.confidentiality == "form.anonymous" %}
-        <li>Your information will be anonymous. This means your responses will not be linked to you.</li>
+        <li>You're giving us information anonymously. No one will know your identity, or who gave your responses.</li>
       {% elif data.confidentiality == "form.public" %}
-        <li>Your information will be public. Your input will be associated with your name.</li>
+        <li>The information you give us can be linked to you, and might be shared outside of CDS.</li>
       {% elif data.confidentiality == "form.not_confidential" %}
-        <li>Your information will not be confidential. Your input will be associated with your name.</li>
+        <li>The information you give us could be used to identify you. The information will not be shared outside of CDS.</li>
       {% endif %}
 
       {% if data.compensation == "yes" %}
-         <li>The fact that you participated will not be confidential.</li>
+         <li>A record of your payment will be publicly available.</li>
       {% endif %}
 
       {% if data.confidentiality == "form.public" %}
-        <li>CDS will share publicly {{ defaultValue("personal_information_disclosed_to_public") }}.</li>
+        <li>CDS might share {{ defaultValue("personal_information_disclosed_to_public") }} from this session in public.</li>
       {% endif %}
 
       {% if data.confidentiality == "form.anonymous" or data.confidentiality == "form.anonymized" %}
-        <li>Due to this, you will not be able to withdraw or correct your information once provided.</li>
+        <li>As we will not be able to link what you told us to your name, you will not be able to withdraw or correct your information after the session.</li>
       {% endif %}
-
+    </ul>
       {% if data.confidentiality == "form.anonymous" %}
-        <li>Please do not provide any information in your responses that would identify you.</li>
+        <p>Do not provide any information in your responses that could identify you.</p>
       {% endif %}
-
+    <ul>
       {% if data.administrative_decision == "yes" %}
-        <li>Your personal information will be used to {{ defaultValue("administrative_purpose")}}.</li>
+        <li>Your personal information or responses might be used to {{ defaultValue("administrative_purpose")}}.</li>
       {% else %}
         <li>Your participation and answers will not affect your access to Government of Canada services or benefits.</li>
       {% endif %}
 
       {% if data.is_with_partner == "yes" %}
-        <li>CDS and {{ defaultValue("partner_department_acronym")}} may collect your personal information. For example, your {{ defaultValue("personal_information_collected") }}.
-        To learn about how CDS and {{ defaultValue("partner_department_acronym") }} protect your personal information, please see the attached privacy statement.</li>
+        <li>CDS and {{ defaultValue("partner_department_acronym")}} will take a note of your responses and your {{ defaultValue("personal_information_collected") }} as part of this session. Read 'How we'll use your information' to find out how we protect the information you give us.</li>
       {% else %}
-        <li>CDS may collect your personal information. For example, your {{ defaultValue("personal_information_collected") }}. To learn about how CDS protects your personal information, please see the attached privacy statement.</li>
+        <li>CDS will take a note of your responses and your {{ defaultValue("personal_information_collected") }} as part of this session. Read 'How we'll use your information' to find out how we protect the information you give us.</li>
       {% endif %}
 
       {% if data.compensation == "yes" %}
@@ -135,24 +134,23 @@
     {% if data.recording_type == "video and audio" or data.recording_type == "audio only" or data.recording_type == "screen recording with audio" %}
 
       {% if data.recording_type == "video and audio" %}
-        <h3>Optional video recording</h3>
+        <h3>Video recording consent (optional)</h3>
       {% else %}
-        <h3>Optional audio recording</h3>
+        <h3>Audio recording consent (optional)</h3>
       {% endif %}
 
-      <p>Recording our research will help us ensure we capture all of your input. </p>
+      <p>Recording our session will help us make sure we don't miss any of your responses.</p>
 
       <p>By agreeing to be recorded, you understand that:</p>
       <ul>
-        <li>You are choosing to be recorded;</li>
-        <li>You are not to provide any additional information that would allow others to identify you during the recording (e.g. your name, date of birth, address, etc.)</li>
-        <li>Your responses will not be confidential due to your audio likeness in the recording.</li>
+        <li>You must not provide any personal information that could be used to identify you, such as your name, date of birth etc.</li>
+        <li>People who listen to the recording may recognise your voice – therefore your responses cannot be confidential.</li>
       </ul>
         {% if data.will_the_recording_be_disclosed == "yes" %}
           <p>Your responses may be shared with other departments for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed") }}. </p>
-          <p>If you decide to withdraw your consent, CDS will not share your recording further.</p>
-          <p>However, prior to your withdrawal, CDS may have already shared your recording with other departments, which may continue to use the recording for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed") }}.</p>
-          <p>Sharing our sessions with other departments will help illustrate the value of {{ defaultValue("research_method") }}s with users in building better digital services.</p>
+          <p>If you tell us you don't want us to share your recording anymore, we'll stop sharing it.</p>
+          <p>However, if we've already shared it with {{ defaultValue("partner_department_acronym")}}, they may continue to use it to {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed") }}.</p>
+          <p>If you consent, we might share this recording with {{ defaultValue("partner_department_acronym")}} as it helps demonstrate the value of {{ defaultValue("research_method") }}s in building better digital services. We may also use it to {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed") }}.</p>
         {% else %}
 
         {% endif %}
@@ -163,65 +161,62 @@
     {% endif %}
 
 
-    <h3>Privacy Statement</h3>
-    <p>Participation is completely voluntary.</p>
-
-    <h3>What we will collect</h3>
-    <p>By participating in this research you consent that your {{ defaultValue("personal_information_collected") }} will be collected.</p>
-    <h3>How we will use this information</h3>
+    <h3>How we'll use your information</h3>
 
     {% if data.compensation == "no" %}
-      <p>The Canadian Digital Service (CDS) will use this information to {{ defaultValue("research_goal") }}.</p>
-      <p>We collect this information to ensure our research cohorts are diverse and to identify trends in feedback for specific groups.</p>
+      <p>We will use the information you give us to {{ defaultValue("research_goal") }}.</p>
+      <p>We collect {{ defaultValue("personal_information_collected") }} to try to make sure we have a diverse sample of responses, and to identify trends.</p>
     {% else %}
-      <p>The Canadian Digital Service (CDS) will use this information to {{ defaultValue("research_goal") }}.</p>
-      <p>We collect this information to ensure our research cohorts are diverse and to identify trends in feedback for specific groups, and to provide you with compensation.</p>
-      <p>Please note, you may be contacted at a later date to verify you have received compensation.</p>
+      <p>We will use the information you give us to {{ defaultValue("research_goal") }}.</p>
+      <p>We collect {{ defaultValue("personal_information_collected") }} to try to make sure we have a diverse sample of responses, to identify trends, and to provide you with a payment.</p>
+      <p>You might be contacted at a later date to make sure you received your payment.</p>
     {% endif %}
 
     {% if data.administrative_decision == "no" %}
-      <p>This personal information will not be used for any “administrative purposes”. Your information will not be used to make a decision that affects you or your access to Government of Canada services.</p>
-    {% endif %}
-
-    {% if data.recording_type != "no recording" %}
-      <p>If you have consented to being recorded, the recording may be disclosed to other departments for {{ defaultValue("purposes_for_which_the_recording_may_be_disclosed")}}.</p>
+      <p>Your participation, personal information and answers will not be used to make any decisions that affect your access to Government of Canada services.</p>
     {% endif %}
 
     {% if data.compensation == "yes" %}
-      <p>CDS will own the {{ defaultValue("research_method") }} information and may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
+      <p>We (CDS) will own the {{ defaultValue("research_method") }} information you give us. We may share a summary of what we have learned from this research, including quotes or narratives, with other government departments. Your name will not be associated with any of those quotes or narratives.</p>
     {% else %}
-      <p>CDS may publish or share with other government institutions a summary of what we have learned from this research, including quotes or narratives. Your name will not be associated with your responses, quotes, or narratives.</p>
+      <p>We may share a summary of what we have learned from this research, including quotes or narratives, with other government departments. Your name will not be associated with any of those quotes or narratives.</p>
     {% endif %}
 
     <h3>Who we are</h3>
 
-    <p>CDS is part of the Treasury Board of Canada Secretariat (TBS).</p>
+    <p>As part of the Treasury Board of Canada Secretariat (TBS), we have the permission to collect and store personal information from the <i>Financial Administration Act</i>.</p>
     <ul>
-      <li>The collection and use of your personal information by TBS is authorized by the <i>Financial Administration Act</i>. </li>
       {% if data.is_with_partner == "yes" %}
-        <li>The collection and use of your personal information by {{ defaultValue("partner_department_acronym") }} is authorized by <i>{{ defaultValue("partner_department_authority") }}</i>.</li>
+        <li>{{ defaultValue("partner_department_acronym") }} has the permission to collect and store personal information from <i>{{ defaultValue("partner_department_authority") }}</i>.</li>
       {% endif %}
-      <li>The collection, use, and disclosure of your personal information is in accordance with the federal <i>Privacy Act</i>. Under the <i>Privacy Act</i>, you have a right of protection, access to and correction or notation of your personal information.</li>
+    </ul>
+    
+    <h3>Your rights</h3>
+    <p>The <i>Privacy Act</i> gives you the right to: </p>
+    <ul>
+      <li>access the information we hold about you</li>
+      <li>ask us to correct information about you if it's wrong</li>
+      <li>have us add a note to your personal information to say that you have requested a change, if we do not make the change.</li>
+    </ul>
+    <p>You can also tell us to contact people we’ve shared your information with so they can correct it, if:</p>
+    <ul>
+      <li>we shared it in the 2 years before you asked for a change or a correction, and</li>
+      <li>they’ve used it to make an administrative decision about you.</li>
     </ul>
 
     {% if data.compensation == "yes" %}
-      <p>The Standard Personal Information Bank entitled “Outreach Activities, PSU 938” and "Accounts Payable, PSU 931", describes the personal information that may be written down.</p>
-      <p>PSU 938: https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938</p>
-      <p>PSU 931: https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu931</p>
+      <p>The type of information we can hold about you and how we can collect it, is listed in "Outreach Activities - PSU 938" (http://www.infosource.gc.ca/emp/emp03-eng.asp#psu938) and "Accounts Payable - PSU 931" (http://www.infosource.gc.ca/emp/emp03-eng.asp#psu931).</p>
       <p>Information on programs and holdings: https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings.html</p>
     {% else %}
-      <p>The Standard Personal Information Bank entitled “Outreach Activities, PSU 938”, describes the personal information that may be written down.</p>
-      <p>PSU 938: https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938</p>
+      <p>The type of information we can hold about you and how we can collect it, is listed in "Outreach Activities - PSU 938" (http://www.infosource.gc.ca/emp/emp03-eng.asp#psu938).</p>
     {% endif %}
 
-    <h3>Your legal rights</h3>
-
     {% if data.confidentiality == "form.anonymized" or data.confidentiality == "form.anonymous" %}
-      <p>Due to the anonymity of responses, CDS will have no reliable means of associating you with your information provided. This means we will not be able to access or respond to your request for correction to inaccurate information or withdrawal.</p>
+      <p>As we will not be able to link what you told us to your name, you will not be able to withdraw or correct your information after the session.</p>
     {% endif %}
 
     <p>
-      CDS/TBS may record your personal information. If you want to access or correct that personal information, or for any questions or concerns, please contact their privacy office:
+      As well as contacting the researcher named above to ask any questions or to modify your information, you can also contact: 
       <br>
       <br>
       <i>TBS Access to Information and Privacy Coordinator</i>
@@ -232,7 +227,7 @@
     </p>
 
     <p>
-      You can complain to the Office of the Privacy Commissioner of Canada about the handling of your personal information:
+      You can complain to the Office of the Privacy Commissioner of Canada if you're not happy with the way your personal information has been handled:
       <br>
       <br>
       <i>Office of the Privacy Commissioner of Canada</i>


### PR DESCRIPTION
From @keithiopia:

> This is a readable version of the form that the participant has to read and sign. It requires a review (and translation) from Elise. It also needs John Millons to ask ATIP to see if it satisfies our legal requirements (I'm 90% sure it does).

I’ll run this through ATIP in context of our forms research. I don’t see any significant changes from a compliance perspective. We have a separate issue to get translated into French (#153).