### PR TITLE
fix: use node:12.22.12 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM pandoc/core
+FROM node:12.22.12-alpine
 LABEL maintainer="-"
 
-RUN apk add --update nodejs nodejs-npm
-
 ARG GITHUB_SHA_ARG
+ARG PANDOC_VERSION=2.19.2
 
 COPY . /src
 
 WORKDIR /src
 
+# Install pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-linux-amd64.tar.gz \
+    && tar -xvzf pandoc-$PANDOC_VERSION-linux-amd64.tar.gz --strip-components 1 -C /usr/local \
+    && rm -rf pandoc-$PANDOC_VERSION-linux-amd64.tar.gz
+
+# Install node deps
 RUN npm install --quiet --production
 
 EXPOSE 3000


### PR DESCRIPTION
# Summary
Update the Dockerfile used by Heroku to use the `node:12.22.12` base image so we can pin to the expected Node.js 12.x required by the project.  As part of this change, we now need to manually install pandoc.

We moved away from using pandoc/core as the base image because alpine is no longer providing Node.js 12.x packages.

# Related
* #190 