### PR TITLE
bug/lambda_vpc_subnet

### DIFF
--- a/terragrunt/aws/app/inputs.tf
+++ b/terragrunt/aws/app/inputs.tf
@@ -13,7 +13,7 @@ variable "aws_security_group_ids" {
 
 variable "public_subnets_ids" {
   description = "AWS Public Subnet ID used by the EFS mount target."
-  type        = string
+  type        = list(string)
 }
 
 variable "aws_efs_access_point" {

--- a/terragrunt/aws/app/lambda.tf
+++ b/terragrunt/aws/app/lambda.tf
@@ -9,7 +9,7 @@ module "generated_statement_lambda" {
 
   vpc = {
     security_group_ids = [var.aws_security_group_ids]
-    subnet_ids         = [var.public_subnets_ids]
+    subnet_ids         = var.public_subnets_ids
   }
 
   environment_variables = {

--- a/terragrunt/env/production/app/terragrunt.hcl
+++ b/terragrunt/env/production/app/terragrunt.hcl
@@ -9,7 +9,6 @@ dependencies {
 dependency "ecr" {
   config_path = "../ecr"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     aws_ecr_repository_arn = ""
     aws_ecr_repository_url = ""

--- a/terragrunt/env/production/app/terragrunt.hcl
+++ b/terragrunt/env/production/app/terragrunt.hcl
@@ -9,6 +9,7 @@ dependencies {
 dependency "ecr" {
   config_path = "../ecr"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     aws_ecr_repository_arn = ""
     aws_ecr_repository_url = ""


### PR DESCRIPTION
# Summary | Résumé

Small bug on lambda VPC configuration, it was being passed in `list(list(string))` which was causing a REGEX error.