### PR TITLE
bug/add-lambda-efs-full-access

### DIFF
--- a/terragrunt/aws/app/lambda.tf
+++ b/terragrunt/aws/app/lambda.tf
@@ -21,9 +21,17 @@ module "generated_statement_lambda" {
     local_mount_path = "/mnt/access"
   }
 
+  policies = [
+    data.aws_iam_policy.efs_full_access.policy
+  ]
+
 }
 
 resource "aws_lambda_function_url" "generated_statement_url" {
   function_name      = module.generated_statement_lambda.function_name
   authorization_type = "NONE"
+}
+
+data "aws_iam_policy" "efs_full_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess"
 }


### PR DESCRIPTION
# Summary | Résumé

Lambda module didn't have the full access to mount the file system. Added the policy.