### PR TITLE
added egress rule

### DIFF
--- a/terragrunt/aws/vpc/vpc.tf
+++ b/terragrunt/aws/vpc/vpc.tf
@@ -30,3 +30,13 @@ resource "aws_security_group_rule" "efs_ingress" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "efs_egress" {
+  description       = "Allows outbound connections to the internet"
+  type              = "egress"
+  security_group_id = aws_security_group.efs_access_sg.id
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
# Summary | Résumé

Lambda function kept timing out, this is likely due to the egress rule not being configured so there were no outbound connections to the internet.