### PR TITLE
bug/updated-lambda-egress

### DIFF
--- a/terragrunt/aws/vpc/vpc.tf
+++ b/terragrunt/aws/vpc/vpc.tf
@@ -57,3 +57,13 @@ resource "aws_security_group_rule" "lambda_egress" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "lambda_egress_efs" {
+  description       = "Allows outbound connections to the EFS"
+  type              = "egress"
+  security_group_id = aws_security_group.lambda_access_sg.id
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
+  source_security_group_id = aws_security_group.efs_access_sg.id
+}

--- a/terragrunt/aws/vpc/vpc.tf
+++ b/terragrunt/aws/vpc/vpc.tf
@@ -59,11 +59,11 @@ resource "aws_security_group_rule" "lambda_egress" {
 }
 
 resource "aws_security_group_rule" "lambda_egress_efs" {
-  description       = "Allows outbound connections to the EFS"
-  type              = "egress"
-  security_group_id = aws_security_group.lambda_access_sg.id
-  from_port         = 2049
-  to_port           = 2049
-  protocol          = "tcp"
+  description              = "Allows outbound connections to the EFS"
+  type                     = "egress"
+  security_group_id        = aws_security_group.lambda_access_sg.id
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
   source_security_group_id = aws_security_group.efs_access_sg.id
 }


### PR DESCRIPTION
# Summary | Résumé

Added new lambda egress rule to allow Lambda security group to be able to communicate with EFS.