### PR TITLE
feat/route-53-record

### DIFF
--- a/terragrunt/aws/cloudfront/route53.tf
+++ b/terragrunt/aws/cloudfront/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "simplify_privacy_statements_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.simplify_privacy_app_cf_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.simplify_privacy_app_cf_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Added A record pointing the domain to the Cloudfront distribution